### PR TITLE
Limit dynamic table storage elements to reduce dynamic table size

### DIFF
--- a/src/decoder.rs
+++ b/src/decoder.rs
@@ -45,14 +45,14 @@
 //! });
 //! ```
 
-use std::num::Wrapping;
 use std::borrow::Cow;
+use std::num::Wrapping;
 
 use super::huffman::HuffmanDecoder;
 use super::huffman::HuffmanDecoderError;
 
 use super::STATIC_TABLE;
-use super::{StaticTable, HeaderTable};
+use super::{HeaderTable, StaticTable};
 
 /// Decodes an integer encoded with a given prefix size (in bits).
 /// Assumes that the buffer `buf` contains the integer to be decoded,
@@ -61,17 +61,16 @@ use super::{StaticTable, HeaderTable};
 ///
 /// Returns a tuple representing the decoded integer and the number
 /// of bytes from the buffer that were used.
-fn decode_integer(buf: &[u8], prefix_size: u8)
-        -> Result<(usize, usize), DecoderError> {
+fn decode_integer(buf: &[u8], prefix_size: u8) -> Result<(usize, usize), DecoderError> {
     if prefix_size < 1 || prefix_size > 8 {
-        return Err(
-            DecoderError::IntegerDecodingError(
-                IntegerDecodingError::InvalidPrefix));
+        return Err(DecoderError::IntegerDecodingError(
+            IntegerDecodingError::InvalidPrefix,
+        ));
     }
     if buf.len() < 1 {
-        return Err(
-            DecoderError::IntegerDecodingError(
-                IntegerDecodingError::NotEnoughOctets));
+        return Err(DecoderError::IntegerDecodingError(
+            IntegerDecodingError::NotEnoughOctets,
+        ));
     }
 
     // Make sure there's no overflow in the shift operation
@@ -109,16 +108,17 @@ fn decode_integer(buf: &[u8], prefix_size: u8)
         if total == octet_limit {
             // The spec tells us that we MUST treat situations where the
             // encoded representation is too long (in octets) as an error.
-            return Err(
-                DecoderError::IntegerDecodingError(
-                    IntegerDecodingError::TooManyOctets))
+            return Err(DecoderError::IntegerDecodingError(
+                IntegerDecodingError::TooManyOctets,
+            ));
         }
     }
 
     // If we have reached here, it means the buffer has been exhausted without
     // hitting the termination condition.
     Err(DecoderError::IntegerDecodingError(
-            IntegerDecodingError::NotEnoughOctets))
+        IntegerDecodingError::NotEnoughOctets,
+    ))
 }
 
 /// Decodes an octet string under HPACK rules of encoding found in the given
@@ -130,12 +130,12 @@ fn decode_integer(buf: &[u8], prefix_size: u8)
 /// Returns the decoded string in a newly allocated `Vec` and the number of
 /// bytes consumed from the given buffer.
 fn decode_string<'a>(buf: &'a [u8]) -> Result<(Cow<'a, [u8]>, usize), DecoderError> {
-    let (len, consumed) = try!(decode_integer(buf, 7));
+    let (len, consumed) = decode_integer(buf, 7)?;
     debug!("decode_string: Consumed = {}, len = {}", consumed, len);
     if consumed + len > buf.len() {
-        return Err(
-            DecoderError::StringDecodingError(
-                StringDecodingError::NotEnoughOctets));
+        return Err(DecoderError::StringDecodingError(
+            StringDecodingError::NotEnoughOctets,
+        ));
     }
     let raw_string = &buf[consumed..consumed + len];
     if buf[0] & 128 == 128 {
@@ -146,8 +146,9 @@ fn decode_string<'a>(buf: &'a [u8]) -> Result<(Cow<'a, [u8]>, usize), DecoderErr
         let decoded = match decoder.decode(raw_string) {
             Err(e) => {
                 return Err(DecoderError::StringDecodingError(
-                    StringDecodingError::HuffmanDecoderError(e)));
-            },
+                    StringDecodingError::HuffmanDecoderError(e),
+                ));
+            }
             Ok(res) => res,
         };
         Ok((Cow::Owned(decoded), consumed + len))
@@ -195,10 +196,7 @@ impl FieldRepresentation {
 
 /// Represents all errors that can be encountered while decoding an
 /// integer.
-#[derive(PartialEq)]
-#[derive(Copy)]
-#[derive(Clone)]
-#[derive(Debug)]
+#[derive(PartialEq, Copy, Clone, Debug)]
 pub enum IntegerDecodingError {
     /// 5.1. specifies that "excessively large integer decodings" MUST be
     /// considered an error (whether the size is the number of octets or
@@ -217,10 +215,7 @@ pub enum IntegerDecodingError {
 
 /// Represents all errors that can be encountered while decoding an octet
 /// string.
-#[derive(PartialEq)]
-#[derive(Copy)]
-#[derive(Clone)]
-#[derive(Debug)]
+#[derive(PartialEq, Copy, Clone, Debug)]
 pub enum StringDecodingError {
     NotEnoughOctets,
     HuffmanDecoderError(HuffmanDecoderError),
@@ -228,10 +223,7 @@ pub enum StringDecodingError {
 
 /// Represents all errors that can be encountered while performing the decoding
 /// of an HPACK header set.
-#[derive(PartialEq)]
-#[derive(Copy)]
-#[derive(Clone)]
-#[derive(Debug)]
+#[derive(PartialEq, Copy, Clone, Debug)]
 pub enum DecoderError {
     HeaderIndexOutOfBounds,
     IntegerDecodingError(IntegerDecodingError),
@@ -274,13 +266,15 @@ impl<'a> Decoder<'a> {
     ///       the one defined in the HPACK spec.
     fn with_static_table(static_table: StaticTable<'a>) -> Decoder<'a> {
         Decoder {
-            header_table: HeaderTable::with_static_table(static_table)
+            header_table: HeaderTable::with_static_table(static_table),
         }
     }
 
     /// Sets a new maximum dynamic table size for the decoder.
     pub fn set_max_table_size(&mut self, new_max_size: usize) {
-        self.header_table.dynamic_table.set_max_table_size(new_max_size);
+        self.header_table
+            .dynamic_table
+            .set_max_table_size(new_max_size);
     }
 
     /// Decodes the headers found in the given buffer `buf`. Invokes the callback `cb` for each
@@ -299,7 +293,9 @@ impl<'a> Decoder<'a> {
     /// If an error is encountered during the decoding of any header, decoding halts and the
     /// appropriate error is returned as the `Err` variant of the `Result`.
     pub fn decode_with_cb<F>(&mut self, buf: &[u8], mut cb: F) -> Result<(), DecoderError>
-            where F: FnMut(Cow<[u8]>, Cow<[u8]>) {
+    where
+        F: FnMut(Cow<[u8]>, Cow<[u8]>),
+    {
         let mut current_octet_index = 0;
 
         while current_octet_index < buf.len() {
@@ -311,16 +307,15 @@ impl<'a> Decoder<'a> {
             let buffer_leftover = &buf[current_octet_index..];
             let consumed = match FieldRepresentation::new(initial_octet) {
                 FieldRepresentation::Indexed => {
-                    let ((name, value), consumed) =
-                        try!(self.decode_indexed(buffer_leftover));
+                    let ((name, value), consumed) = self.decode_indexed(buffer_leftover)?;
                     cb(Cow::Borrowed(name), Cow::Borrowed(value));
 
                     consumed
-                },
+                }
                 FieldRepresentation::LiteralWithIncrementalIndexing => {
                     let ((name, value), consumed) = {
-                        let ((name, value), consumed) = try!(
-                            self.decode_literal(buffer_leftover, true));
+                        let ((name, value), consumed) =
+                            self.decode_literal(buffer_leftover, true)?;
                         cb(Cow::Borrowed(&name), Cow::Borrowed(&value));
 
                         // Since we are to add the decoded header to the header table, we need to
@@ -338,25 +333,23 @@ impl<'a> Decoder<'a> {
                     self.header_table.add_header(name, value);
 
                     consumed
-                },
+                }
                 FieldRepresentation::LiteralWithoutIndexing => {
-                    let ((name, value), consumed) =
-                        try!(self.decode_literal(buffer_leftover, false));
+                    let ((name, value), consumed) = self.decode_literal(buffer_leftover, false)?;
                     cb(name, value);
 
                     consumed
-                },
+                }
                 FieldRepresentation::LiteralNeverIndexed => {
                     // Same as the previous one, except if we were also a proxy
                     // we would need to make sure not to change the
                     // representation received here. We don't care about this
                     // for now.
-                    let ((name, value), consumed) =
-                        try!(self.decode_literal(buffer_leftover, false));
+                    let ((name, value), consumed) = self.decode_literal(buffer_leftover, false)?;
                     cb(name, value);
 
                     consumed
-                },
+                }
                 FieldRepresentation::SizeUpdate => {
                     // Handle the dynamic table size update...
                     self.update_max_dynamic_size(buffer_leftover)
@@ -380,18 +373,22 @@ impl<'a> Decoder<'a> {
     pub fn decode(&mut self, buf: &[u8]) -> DecoderResult {
         let mut header_list = Vec::new();
 
-        try!(self.decode_with_cb(buf, |n, v| header_list.push((n.into_owned(), v.into_owned()))));
+        self.decode_with_cb(buf, |n, v| {
+            header_list.push((n.into_owned(), v.into_owned()))
+        })?;
 
         Ok(header_list)
     }
 
     /// Decodes an indexed header representation.
-    fn decode_indexed(&self, buf: &[u8])
-            -> Result<((&[u8], &[u8]), usize), DecoderError> {
-        let (index, consumed) = try!(decode_integer(buf, 7));
-        debug!("Decoding indexed: index = {}, consumed = {}", index, consumed);
+    fn decode_indexed(&self, buf: &[u8]) -> Result<((&[u8], &[u8]), usize), DecoderError> {
+        let (index, consumed) = decode_integer(buf, 7)?;
+        debug!(
+            "Decoding indexed: index = {}, consumed = {}",
+            index, consumed
+        );
 
-        let (name, value) = try!(self.get_from_table(index));
+        let (name, value) = self.get_from_table(index)?;
 
         Ok(((name, value), consumed))
     }
@@ -401,10 +398,10 @@ impl<'a> Decoder<'a> {
     /// In this context, the "table" references the definition of the table
     /// where the static table is concatenated with the dynamic table and is
     /// 1-indexed.
-    fn get_from_table(&self, index: usize)
-            -> Result<(&[u8], &[u8]), DecoderError> {
-        self.header_table.get_from_table(index).ok_or(
-            DecoderError::HeaderIndexOutOfBounds)
+    fn get_from_table(&self, index: usize) -> Result<(&[u8], &[u8]), DecoderError> {
+        self.header_table
+            .get_from_table(index)
+            .ok_or(DecoderError::HeaderIndexOutOfBounds)
     }
 
     /// Decodes a literal header representation from the given buffer.
@@ -413,29 +410,28 @@ impl<'a> Decoder<'a> {
     ///
     /// - index: whether or not the decoded value should be indexed (i.e.
     ///   included in the dynamic table).
-    fn decode_literal<'b>(&'b self, buf: &'b [u8], index: bool)
-            -> Result<((Cow<[u8]>, Cow<[u8]>), usize), DecoderError> {
-        let prefix = if index {
-            6
-        } else {
-            4
-        };
-        let (table_index, mut consumed) = try!(decode_integer(buf, prefix));
+    fn decode_literal<'b>(
+        &'b self,
+        buf: &'b [u8],
+        index: bool,
+    ) -> Result<((Cow<[u8]>, Cow<[u8]>), usize), DecoderError> {
+        let prefix = if index { 6 } else { 4 };
+        let (table_index, mut consumed) = decode_integer(buf, prefix)?;
 
         // First read the name appropriately
         let name = if table_index == 0 {
             // Read name string as literal
-            let (name, name_len) = try!(decode_string(&buf[consumed..]));
+            let (name, name_len) = decode_string(&buf[consumed..])?;
             consumed += name_len;
             name
         } else {
             // Read name indexed from the table
-            let (name, _) = try!(self.get_from_table(table_index));
+            let (name, _) = self.get_from_table(table_index)?;
             Cow::Borrowed(name)
         };
 
         // Now read the value as a literal...
-        let (value, value_len) = try!(decode_string(&buf[consumed..]));
+        let (value, value_len) = decode_string(&buf[consumed..])?;
         consumed += value_len;
 
         Ok(((name, value), consumed))
@@ -453,9 +449,11 @@ impl<'a> Decoder<'a> {
         let (new_size, consumed) = decode_integer(buf, 5).ok().unwrap();
         self.header_table.dynamic_table.set_max_table_size(new_size);
 
-        info!("Decoder changed max table size from {} to {}",
-              self.header_table.dynamic_table.get_size(),
-              new_size);
+        info!(
+            "Decoder changed max table size from {} to {}",
+            self.header_table.dynamic_table.get_size(),
+            new_size
+        );
 
         consumed
     }
@@ -463,31 +461,35 @@ impl<'a> Decoder<'a> {
 
 #[cfg(test)]
 mod tests {
-    use super::{decode_integer};
+    use super::decode_integer;
 
     use std::borrow::Cow;
 
     use super::super::encoder::encode_integer;
-    use super::FieldRepresentation;
+    use super::super::huffman::HuffmanDecoderError;
     use super::decode_string;
     use super::Decoder;
+    use super::FieldRepresentation;
     use super::{DecoderError, DecoderResult};
     use super::{IntegerDecodingError, StringDecodingError};
-    use super::super::huffman::HuffmanDecoderError;
 
     /// Tests that valid integer encodings are properly decoded.
     #[test]
     fn test_decode_integer() {
-        assert_eq!((10, 1),
-                   decode_integer(&[10], 5).ok().unwrap());
-        assert_eq!((1337, 3),
-                   decode_integer(&[31, 154, 10], 5).ok().unwrap());
-        assert_eq!((1337, 3),
-                   decode_integer(&[31 + 32, 154, 10], 5).ok().unwrap());
-        assert_eq!((1337, 3),
-                   decode_integer(&[31 + 64, 154, 10], 5).ok().unwrap());
-        assert_eq!((1337, 3),
-                   decode_integer(&[31, 154, 10, 111, 22], 5).ok().unwrap());
+        assert_eq!((10, 1), decode_integer(&[10], 5).ok().unwrap());
+        assert_eq!((1337, 3), decode_integer(&[31, 154, 10], 5).ok().unwrap());
+        assert_eq!(
+            (1337, 3),
+            decode_integer(&[31 + 32, 154, 10], 5).ok().unwrap()
+        );
+        assert_eq!(
+            (1337, 3),
+            decode_integer(&[31 + 64, 154, 10], 5).ok().unwrap()
+        );
+        assert_eq!(
+            (1337, 3),
+            decode_integer(&[31, 154, 10, 111, 22], 5).ok().unwrap()
+        );
 
         assert_eq!((127, 2), decode_integer(&[255, 0], 7).ok().unwrap());
         assert_eq!((127, 2), decode_integer(&[127, 0], 7).ok().unwrap());
@@ -499,7 +501,10 @@ mod tests {
         // The largest allowed integer correctly gets decoded...
         assert_eq!(
             (268435710, 5),
-            decode_integer(&[0xFF, 0xFF, 0xFF, 0xFF, 0xFF - 128], 8).ok().unwrap());
+            decode_integer(&[0xFF, 0xFF, 0xFF, 0xFF, 0xFF - 128], 8)
+                .ok()
+                .unwrap()
+        );
     }
 
     /// A helper macro that asserts that a given `DecoderResult` represents
@@ -517,19 +522,33 @@ mod tests {
     /// errors.
     #[test]
     fn test_decode_integer_errors() {
-        assert_integer_err!(IntegerDecodingError::NotEnoughOctets,
-                            decode_integer(&[], 5));
-        assert_integer_err!(IntegerDecodingError::NotEnoughOctets,
-                            decode_integer(&[0xFF, 0xFF], 5));
-        assert_integer_err!(IntegerDecodingError::TooManyOctets,
-                            decode_integer(&[0xFF, 0x80, 0x80, 0x80, 0x80,
-                                             0x80, 0x80, 0x80, 0x80, 0x80], 1));
-        assert_integer_err!(IntegerDecodingError::TooManyOctets,
-                            decode_integer(&[0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0x0], 8));
-        assert_integer_err!(IntegerDecodingError::InvalidPrefix,
-                            decode_integer(&[10], 0));
-        assert_integer_err!(IntegerDecodingError::InvalidPrefix,
-                            decode_integer(&[10], 9));
+        assert_integer_err!(
+            IntegerDecodingError::NotEnoughOctets,
+            decode_integer(&[], 5)
+        );
+        assert_integer_err!(
+            IntegerDecodingError::NotEnoughOctets,
+            decode_integer(&[0xFF, 0xFF], 5)
+        );
+        assert_integer_err!(
+            IntegerDecodingError::TooManyOctets,
+            decode_integer(
+                &[0xFF, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80],
+                1
+            )
+        );
+        assert_integer_err!(
+            IntegerDecodingError::TooManyOctets,
+            decode_integer(&[0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0x0], 8)
+        );
+        assert_integer_err!(
+            IntegerDecodingError::InvalidPrefix,
+            decode_integer(&[10], 0)
+        );
+        assert_integer_err!(
+            IntegerDecodingError::InvalidPrefix,
+            decode_integer(&[10], 9)
+        );
     }
 
     #[test]
@@ -629,26 +648,33 @@ mod tests {
             };
         }
 
-        assert_eq!((Cow::Borrowed(&b"abc"[..]), 4),
-                   decode_string(&[3, b'a', b'b', b'c']).ok().unwrap());
-        assert_eq!((Cow::Borrowed(&b"a"[..]), 2),
-                   decode_string(&[1, b'a']).ok().unwrap());
-        assert_eq!((Cow::Borrowed(&b""[..]), 1),
-                   decode_string(&[0, b'a']).ok().unwrap());
+        assert_eq!(
+            (Cow::Borrowed(&b"abc"[..]), 4),
+            decode_string(&[3, b'a', b'b', b'c']).ok().unwrap()
+        );
+        assert_eq!(
+            (Cow::Borrowed(&b"a"[..]), 2),
+            decode_string(&[1, b'a']).ok().unwrap()
+        );
+        assert_eq!(
+            (Cow::Borrowed(&b""[..]), 1),
+            decode_string(&[0, b'a']).ok().unwrap()
+        );
 
-        assert_borrowed_eq((&b"abc"[..], 4),
-                           decode_string(&[3, b'a', b'b', b'c']).ok().unwrap());
-        assert_borrowed_eq((&b"a"[..], 2),
-                           decode_string(&[1, b'a']).ok().unwrap());
-        assert_borrowed_eq((&b""[..], 1),
-                           decode_string(&[0, b'a']).ok().unwrap());
+        assert_borrowed_eq(
+            (&b"abc"[..], 4),
+            decode_string(&[3, b'a', b'b', b'c']).ok().unwrap(),
+        );
+        assert_borrowed_eq((&b"a"[..], 2), decode_string(&[1, b'a']).ok().unwrap());
+        assert_borrowed_eq((&b""[..], 1), decode_string(&[0, b'a']).ok().unwrap());
 
         // Buffer smaller than advertised string length
-        assert_eq!(StringDecodingError::NotEnoughOctets,
-                   match decode_string(&[3, b'a', b'b']) {
-                       Err(DecoderError::StringDecodingError(e)) => e,
-                       _ => panic!("Expected NotEnoughOctets error!"),
-                    }
+        assert_eq!(
+            StringDecodingError::NotEnoughOctets,
+            match decode_string(&[3, b'a', b'b']) {
+                Err(DecoderError::StringDecodingError(e)) => e,
+                _ => panic!("Expected NotEnoughOctets error!"),
+            }
         );
     }
 
@@ -663,7 +689,8 @@ mod tests {
 
             assert_eq!(
                 (Cow::Owned(full_string), encoded.len()),
-                decode_string(&encoded).ok().unwrap());
+                decode_string(&encoded).ok().unwrap()
+            );
         }
         {
             let full_string: Vec<u8> = (0u8..127).collect();
@@ -672,7 +699,8 @@ mod tests {
 
             assert_eq!(
                 (Cow::Owned(full_string), encoded.len()),
-                decode_string(&encoded).ok().unwrap());
+                decode_string(&encoded).ok().unwrap()
+            );
         }
     }
 
@@ -694,11 +722,14 @@ mod tests {
 
         let header_list = decoder.decode(&[0x82, 0x86, 0x84]).ok().unwrap();
 
-        assert_eq!(header_list, [
-            (b":method".to_vec(), b"GET".to_vec()),
-            (b":scheme".to_vec(), b"http".to_vec()),
-            (b":path".to_vec(), b"/".to_vec()),
-        ]);
+        assert_eq!(
+            header_list,
+            [
+                (b":method".to_vec(), b"GET".to_vec()),
+                (b":scheme".to_vec(), b"http".to_vec()),
+                (b":path".to_vec(), b"/".to_vec()),
+            ]
+        );
     }
 
     /// Tests that a literal with an indexed name and literal value is correctly
@@ -708,15 +739,15 @@ mod tests {
     fn test_decode_literal_indexed_name() {
         let mut decoder = Decoder::new();
         let hex_dump = [
-            0x04, 0x0c, 0x2f, 0x73, 0x61, 0x6d, 0x70,
-            0x6c, 0x65, 0x2f, 0x70, 0x61, 0x74, 0x68,
+            0x04, 0x0c, 0x2f, 0x73, 0x61, 0x6d, 0x70, 0x6c, 0x65, 0x2f, 0x70, 0x61, 0x74, 0x68,
         ];
 
         let header_list = decoder.decode(&hex_dump).ok().unwrap();
 
-        assert_eq!(header_list, [
-            (b":path".to_vec(), b"/sample/path".to_vec()),
-        ]);
+        assert_eq!(
+            header_list,
+            [(b":path".to_vec(), b"/sample/path".to_vec()),]
+        );
         // Nothing was added to the dynamic table
         assert_eq!(decoder.header_table.dynamic_table.len(), 0);
     }
@@ -728,21 +759,19 @@ mod tests {
     fn test_decode_literal_both() {
         let mut decoder = Decoder::new();
         let hex_dump = [
-            0x40, 0x0a, 0x63, 0x75, 0x73, 0x74, 0x6f, 0x6d, 0x2d, 0x6b, 0x65,
-            0x79, 0x0d, 0x63, 0x75, 0x73, 0x74, 0x6f, 0x6d, 0x2d, 0x68, 0x65,
-            0x61, 0x64, 0x65, 0x72,
+            0x40, 0x0a, 0x63, 0x75, 0x73, 0x74, 0x6f, 0x6d, 0x2d, 0x6b, 0x65, 0x79, 0x0d, 0x63,
+            0x75, 0x73, 0x74, 0x6f, 0x6d, 0x2d, 0x68, 0x65, 0x61, 0x64, 0x65, 0x72,
         ];
 
         let header_list = decoder.decode(&hex_dump).ok().unwrap();
 
-        assert_eq!(header_list, [
-            (b"custom-key".to_vec(), b"custom-header".to_vec()),
-        ]);
+        assert_eq!(
+            header_list,
+            [(b"custom-key".to_vec(), b"custom-header".to_vec()),]
+        );
         // The entry got added to the dynamic table?
         assert_eq!(decoder.header_table.dynamic_table.len(), 1);
-        let expected_table = vec![
-            (b"custom-key".to_vec(), b"custom-header".to_vec())
-        ];
+        let expected_table = vec![(b"custom-key".to_vec(), b"custom-header".to_vec())];
         let actual = decoder.header_table.dynamic_table.to_vec();
         assert_eq!(actual, expected_table);
     }
@@ -755,36 +784,48 @@ mod tests {
         {
             // Prepares the context: the dynamic table contains a custom-key.
             let hex_dump = [
-                0x40, 0x0a, 0x63, 0x75, 0x73, 0x74, 0x6f, 0x6d, 0x2d, 0x6b,
-                0x65, 0x79, 0x0d, 0x63, 0x75, 0x73, 0x74, 0x6f, 0x6d, 0x2d,
-                0x68, 0x65, 0x61, 0x64, 0x65, 0x72,
+                0x40, 0x0a, 0x63, 0x75, 0x73, 0x74, 0x6f, 0x6d, 0x2d, 0x6b, 0x65, 0x79, 0x0d, 0x63,
+                0x75, 0x73, 0x74, 0x6f, 0x6d, 0x2d, 0x68, 0x65, 0x61, 0x64, 0x65, 0x72,
             ];
 
             let header_list = decoder.decode(&hex_dump).ok().unwrap();
 
-            assert_eq!(header_list, [
-                (b"custom-key".to_vec(), b"custom-header".to_vec()),
-            ]);
+            assert_eq!(
+                header_list,
+                [(b"custom-key".to_vec(), b"custom-header".to_vec()),]
+            );
             // The entry got added to the dynamic table?
             assert_eq!(decoder.header_table.dynamic_table.len(), 1);
-            let expected_table = vec![
-                (b"custom-key".to_vec(), b"custom-header".to_vec())
-            ];
+            let expected_table = vec![(b"custom-key".to_vec(), b"custom-header".to_vec())];
             let actual = decoder.header_table.dynamic_table.to_vec();
             assert_eq!(actual, expected_table);
         }
         {
             let hex_dump = [
-                0x40 + 62,  // Index 62 in the table => 1st in dynamic table
-                0x0e, 0x63, 0x75, 0x73, 0x74, 0x6f, 0x6d, 0x2d, 0x68, 0x65,
-                0x61, 0x64, 0x65, 0x72, 0x2d,
+                0x40 + 62, // Index 62 in the table => 1st in dynamic table
+                0x0e,
+                0x63,
+                0x75,
+                0x73,
+                0x74,
+                0x6f,
+                0x6d,
+                0x2d,
+                0x68,
+                0x65,
+                0x61,
+                0x64,
+                0x65,
+                0x72,
+                0x2d,
             ];
 
             let header_list = decoder.decode(&hex_dump).ok().unwrap();
 
-            assert_eq!(header_list, [
-                (b"custom-key".to_vec(), b"custom-header-".to_vec()),
-            ]);
+            assert_eq!(
+                header_list,
+                [(b"custom-key".to_vec(), b"custom-header-".to_vec()),]
+            );
             // The entry got added to the dynamic table, so now we have two?
             assert_eq!(decoder.header_table.dynamic_table.len(), 2);
             let expected_table = vec![
@@ -803,15 +844,13 @@ mod tests {
     fn test_decode_literal_field_never_indexed() {
         let mut decoder = Decoder::new();
         let hex_dump = [
-            0x10, 0x08, 0x70, 0x61, 0x73, 0x73, 0x77, 0x6f, 0x72, 0x64, 0x06,
-            0x73, 0x65, 0x63, 0x72, 0x65, 0x74,
+            0x10, 0x08, 0x70, 0x61, 0x73, 0x73, 0x77, 0x6f, 0x72, 0x64, 0x06, 0x73, 0x65, 0x63,
+            0x72, 0x65, 0x74,
         ];
 
         let header_list = decoder.decode(&hex_dump).ok().unwrap();
 
-        assert_eq!(header_list, [
-            (b"password".to_vec(), b"secret".to_vec()),
-        ]);
+        assert_eq!(header_list, [(b"password".to_vec(), b"secret".to_vec()),]);
         // Nothing was added to the dynamic table
         assert_eq!(decoder.header_table.dynamic_table.len(), 0);
     }
@@ -825,42 +864,45 @@ mod tests {
         {
             // First Request (C.3.1.)
             let hex_dump = [
-                0x82, 0x86, 0x84, 0x41, 0x0f, 0x77, 0x77, 0x77, 0x2e, 0x65,
-                0x78, 0x61, 0x6d, 0x70, 0x6c, 0x65, 0x2e, 0x63, 0x6f, 0x6d,
+                0x82, 0x86, 0x84, 0x41, 0x0f, 0x77, 0x77, 0x77, 0x2e, 0x65, 0x78, 0x61, 0x6d, 0x70,
+                0x6c, 0x65, 0x2e, 0x63, 0x6f, 0x6d,
             ];
 
             let header_list = decoder.decode(&hex_dump).ok().unwrap();
 
-            assert_eq!(header_list, [
-                (b":method".to_vec(), b"GET".to_vec()),
-                (b":scheme".to_vec(), b"http".to_vec()),
-                (b":path".to_vec(), b"/".to_vec()),
-                (b":authority".to_vec(), b"www.example.com".to_vec()),
-            ]);
+            assert_eq!(
+                header_list,
+                [
+                    (b":method".to_vec(), b"GET".to_vec()),
+                    (b":scheme".to_vec(), b"http".to_vec()),
+                    (b":path".to_vec(), b"/".to_vec()),
+                    (b":authority".to_vec(), b"www.example.com".to_vec()),
+                ]
+            );
             // Only one entry got added to the dynamic table?
             assert_eq!(decoder.header_table.dynamic_table.len(), 1);
-            let expected_table = vec![
-                (b":authority".to_vec(), b"www.example.com".to_vec())
-            ];
+            let expected_table = vec![(b":authority".to_vec(), b"www.example.com".to_vec())];
             let actual = decoder.header_table.dynamic_table.to_vec();
             assert_eq!(actual, expected_table);
         }
         {
             // Second Request (C.3.2.)
             let hex_dump = [
-                0x82, 0x86, 0x84, 0xbe, 0x58, 0x08, 0x6e, 0x6f, 0x2d, 0x63,
-                0x61, 0x63, 0x68, 0x65,
+                0x82, 0x86, 0x84, 0xbe, 0x58, 0x08, 0x6e, 0x6f, 0x2d, 0x63, 0x61, 0x63, 0x68, 0x65,
             ];
 
             let header_list = decoder.decode(&hex_dump).ok().unwrap();
 
-            assert_eq!(header_list, [
-                (b":method".to_vec(), b"GET".to_vec()),
-                (b":scheme".to_vec(), b"http".to_vec()),
-                (b":path".to_vec(), b"/".to_vec()),
-                (b":authority".to_vec(), b"www.example.com".to_vec()),
-                (b"cache-control".to_vec(), b"no-cache".to_vec()),
-            ]);
+            assert_eq!(
+                header_list,
+                [
+                    (b":method".to_vec(), b"GET".to_vec()),
+                    (b":scheme".to_vec(), b"http".to_vec()),
+                    (b":path".to_vec(), b"/".to_vec()),
+                    (b":authority".to_vec(), b"www.example.com".to_vec()),
+                    (b"cache-control".to_vec(), b"no-cache".to_vec()),
+                ]
+            );
             // One entry got added to the dynamic table, so we have two?
             let expected_table = vec![
                 (b"cache-control".to_vec(), b"no-cache".to_vec()),
@@ -872,20 +914,23 @@ mod tests {
         {
             // Third Request (C.3.3.)
             let hex_dump = [
-                0x82, 0x87, 0x85, 0xbf, 0x40, 0x0a, 0x63, 0x75, 0x73, 0x74,
-                0x6f, 0x6d, 0x2d, 0x6b, 0x65, 0x79, 0x0c, 0x63, 0x75, 0x73,
-                0x74, 0x6f, 0x6d, 0x2d, 0x76, 0x61, 0x6c, 0x75, 0x65,
+                0x82, 0x87, 0x85, 0xbf, 0x40, 0x0a, 0x63, 0x75, 0x73, 0x74, 0x6f, 0x6d, 0x2d, 0x6b,
+                0x65, 0x79, 0x0c, 0x63, 0x75, 0x73, 0x74, 0x6f, 0x6d, 0x2d, 0x76, 0x61, 0x6c, 0x75,
+                0x65,
             ];
 
             let header_list = decoder.decode(&hex_dump).ok().unwrap();
 
-            assert_eq!(header_list, [
-                (b":method".to_vec(), b"GET".to_vec()),
-                (b":scheme".to_vec(), b"https".to_vec()),
-                (b":path".to_vec(), b"/index.html".to_vec()),
-                (b":authority".to_vec(), b"www.example.com".to_vec()),
-                (b"custom-key".to_vec(), b"custom-value".to_vec()),
-            ]);
+            assert_eq!(
+                header_list,
+                [
+                    (b":method".to_vec(), b"GET".to_vec()),
+                    (b":scheme".to_vec(), b"https".to_vec()),
+                    (b":path".to_vec(), b"/index.html".to_vec()),
+                    (b":authority".to_vec(), b"www.example.com".to_vec()),
+                    (b"custom-key".to_vec(), b"custom-value".to_vec()),
+                ]
+            );
             // One entry got added to the dynamic table, so we have three at
             // this point...?
             let expected_table = vec![
@@ -909,23 +954,24 @@ mod tests {
         {
             // First Response (C.5.1.)
             let hex_dump = [
-                0x48, 0x03, 0x33, 0x30, 0x32, 0x58, 0x07, 0x70, 0x72, 0x69,
-                0x76, 0x61, 0x74, 0x65, 0x61, 0x1d, 0x4d, 0x6f, 0x6e, 0x2c,
-                0x20, 0x32, 0x31, 0x20, 0x4f, 0x63, 0x74, 0x20, 0x32, 0x30,
-                0x31, 0x33, 0x20, 0x32, 0x30, 0x3a, 0x31, 0x33, 0x3a, 0x32,
-                0x31, 0x20, 0x47, 0x4d, 0x54, 0x6e, 0x17, 0x68, 0x74, 0x74,
-                0x70, 0x73, 0x3a, 0x2f, 0x2f, 0x77, 0x77, 0x77, 0x2e, 0x65,
-                0x78, 0x61, 0x6d, 0x70, 0x6c, 0x65, 0x2e, 0x63, 0x6f, 0x6d,
+                0x48, 0x03, 0x33, 0x30, 0x32, 0x58, 0x07, 0x70, 0x72, 0x69, 0x76, 0x61, 0x74, 0x65,
+                0x61, 0x1d, 0x4d, 0x6f, 0x6e, 0x2c, 0x20, 0x32, 0x31, 0x20, 0x4f, 0x63, 0x74, 0x20,
+                0x32, 0x30, 0x31, 0x33, 0x20, 0x32, 0x30, 0x3a, 0x31, 0x33, 0x3a, 0x32, 0x31, 0x20,
+                0x47, 0x4d, 0x54, 0x6e, 0x17, 0x68, 0x74, 0x74, 0x70, 0x73, 0x3a, 0x2f, 0x2f, 0x77,
+                0x77, 0x77, 0x2e, 0x65, 0x78, 0x61, 0x6d, 0x70, 0x6c, 0x65, 0x2e, 0x63, 0x6f, 0x6d,
             ];
 
             let header_list = decoder.decode(&hex_dump).ok().unwrap();
 
-            assert_eq!(header_list, [
-                (b":status".to_vec(), b"302".to_vec()),
-                (b"cache-control".to_vec(), b"private".to_vec()),
-                (b"date".to_vec(), b"Mon, 21 Oct 2013 20:13:21 GMT".to_vec()),
-                (b"location".to_vec(), b"https://www.example.com".to_vec()),
-            ]);
+            assert_eq!(
+                header_list,
+                [
+                    (b":status".to_vec(), b"302".to_vec()),
+                    (b"cache-control".to_vec(), b"private".to_vec()),
+                    (b"date".to_vec(), b"Mon, 21 Oct 2013 20:13:21 GMT".to_vec()),
+                    (b"location".to_vec(), b"https://www.example.com".to_vec()),
+                ]
+            );
             // All entries in the dynamic table too?
             let expected_table = vec![
                 (b"location".to_vec(), b"https://www.example.com".to_vec()),
@@ -938,18 +984,19 @@ mod tests {
         }
         {
             // Second Response (C.5.2.)
-            let hex_dump = [
-                0x48, 0x03, 0x33, 0x30, 0x37, 0xc1, 0xc0, 0xbf,
-            ];
+            let hex_dump = [0x48, 0x03, 0x33, 0x30, 0x37, 0xc1, 0xc0, 0xbf];
 
             let header_list = decoder.decode(&hex_dump).ok().unwrap();
 
-            assert_eq!(header_list, [
-                (b":status".to_vec(), b"307".to_vec()),
-                (b"cache-control".to_vec(), b"private".to_vec()),
-                (b"date".to_vec(), b"Mon, 21 Oct 2013 20:13:21 GMT".to_vec()),
-                (b"location".to_vec(), b"https://www.example.com".to_vec()),
-            ]);
+            assert_eq!(
+                header_list,
+                [
+                    (b":status".to_vec(), b"307".to_vec()),
+                    (b"cache-control".to_vec(), b"private".to_vec()),
+                    (b"date".to_vec(), b"Mon, 21 Oct 2013 20:13:21 GMT".to_vec()),
+                    (b"location".to_vec(), b"https://www.example.com".to_vec()),
+                ]
+            );
             // The new status replaces the old status in the table, since it
             // cannot fit without evicting something from the table.
             let expected_table = vec![
@@ -964,16 +1011,13 @@ mod tests {
         {
             // Third Response (C.5.3.)
             let hex_dump = [
-                0x88, 0xc1, 0x61, 0x1d, 0x4d, 0x6f, 0x6e, 0x2c, 0x20, 0x32,
-                0x31, 0x20, 0x4f, 0x63, 0x74, 0x20, 0x32, 0x30, 0x31, 0x33,
-                0x20, 0x32, 0x30, 0x3a, 0x31, 0x33, 0x3a, 0x32, 0x32, 0x20,
-                0x47, 0x4d, 0x54, 0xc0, 0x5a, 0x04, 0x67, 0x7a, 0x69, 0x70,
-                0x77, 0x38, 0x66, 0x6f, 0x6f, 0x3d, 0x41, 0x53, 0x44, 0x4a,
-                0x4b, 0x48, 0x51, 0x4b, 0x42, 0x5a, 0x58, 0x4f, 0x51, 0x57,
-                0x45, 0x4f, 0x50, 0x49, 0x55, 0x41, 0x58, 0x51, 0x57, 0x45,
-                0x4f, 0x49, 0x55, 0x3b, 0x20, 0x6d, 0x61, 0x78, 0x2d, 0x61,
-                0x67, 0x65, 0x3d, 0x33, 0x36, 0x30, 0x30, 0x3b, 0x20, 0x76,
-                0x65, 0x72, 0x73, 0x69, 0x6f, 0x6e, 0x3d, 0x31,
+                0x88, 0xc1, 0x61, 0x1d, 0x4d, 0x6f, 0x6e, 0x2c, 0x20, 0x32, 0x31, 0x20, 0x4f, 0x63,
+                0x74, 0x20, 0x32, 0x30, 0x31, 0x33, 0x20, 0x32, 0x30, 0x3a, 0x31, 0x33, 0x3a, 0x32,
+                0x32, 0x20, 0x47, 0x4d, 0x54, 0xc0, 0x5a, 0x04, 0x67, 0x7a, 0x69, 0x70, 0x77, 0x38,
+                0x66, 0x6f, 0x6f, 0x3d, 0x41, 0x53, 0x44, 0x4a, 0x4b, 0x48, 0x51, 0x4b, 0x42, 0x5a,
+                0x58, 0x4f, 0x51, 0x57, 0x45, 0x4f, 0x50, 0x49, 0x55, 0x41, 0x58, 0x51, 0x57, 0x45,
+                0x4f, 0x49, 0x55, 0x3b, 0x20, 0x6d, 0x61, 0x78, 0x2d, 0x61, 0x67, 0x65, 0x3d, 0x33,
+                0x36, 0x30, 0x30, 0x3b, 0x20, 0x76, 0x65, 0x72, 0x73, 0x69, 0x6f, 0x6e, 0x3d, 0x31,
             ];
 
             let header_list = decoder.decode(&hex_dump).ok().unwrap();
@@ -986,7 +1030,7 @@ mod tests {
                 (b"content-encoding".to_vec(), b"gzip".to_vec()),
                 (
                     b"set-cookie".to_vec(),
-                    b"foo=ASDJKHQKBZXOQWEOPIUAXQWEOIU; max-age=3600; version=1".to_vec()
+                    b"foo=ASDJKHQKBZXOQWEOPIUAXQWEOIU; max-age=3600; version=1".to_vec(),
                 ),
             ];
             assert_eq!(header_list, expected_header_list);
@@ -995,7 +1039,7 @@ mod tests {
             let expected_table = vec![
                 (
                     b"set-cookie".to_vec(),
-                    b"foo=ASDJKHQKBZXOQWEOPIUAXQWEOIU; max-age=3600; version=1".to_vec()
+                    b"foo=ASDJKHQKBZXOQWEOPIUAXQWEOIU; max-age=3600; version=1".to_vec(),
                 ),
                 (b"content-encoding".to_vec(), b"gzip".to_vec()),
                 (b"date".to_vec(), b"Mon, 21 Oct 2013 20:13:22 GMT".to_vec()),
@@ -1012,23 +1056,24 @@ mod tests {
         let mut decoder = Decoder::new();
         {
             let hex_dump = [
-                0x48, 0x03, 0x33, 0x30, 0x32, 0x58, 0x07, 0x70, 0x72, 0x69,
-                0x76, 0x61, 0x74, 0x65, 0x61, 0x1d, 0x4d, 0x6f, 0x6e, 0x2c,
-                0x20, 0x32, 0x31, 0x20, 0x4f, 0x63, 0x74, 0x20, 0x32, 0x30,
-                0x31, 0x33, 0x20, 0x32, 0x30, 0x3a, 0x31, 0x33, 0x3a, 0x32,
-                0x31, 0x20, 0x47, 0x4d, 0x54, 0x6e, 0x17, 0x68, 0x74, 0x74,
-                0x70, 0x73, 0x3a, 0x2f, 0x2f, 0x77, 0x77, 0x77, 0x2e, 0x65,
-                0x78, 0x61, 0x6d, 0x70, 0x6c, 0x65, 0x2e, 0x63, 0x6f, 0x6d,
+                0x48, 0x03, 0x33, 0x30, 0x32, 0x58, 0x07, 0x70, 0x72, 0x69, 0x76, 0x61, 0x74, 0x65,
+                0x61, 0x1d, 0x4d, 0x6f, 0x6e, 0x2c, 0x20, 0x32, 0x31, 0x20, 0x4f, 0x63, 0x74, 0x20,
+                0x32, 0x30, 0x31, 0x33, 0x20, 0x32, 0x30, 0x3a, 0x31, 0x33, 0x3a, 0x32, 0x31, 0x20,
+                0x47, 0x4d, 0x54, 0x6e, 0x17, 0x68, 0x74, 0x74, 0x70, 0x73, 0x3a, 0x2f, 0x2f, 0x77,
+                0x77, 0x77, 0x2e, 0x65, 0x78, 0x61, 0x6d, 0x70, 0x6c, 0x65, 0x2e, 0x63, 0x6f, 0x6d,
             ];
 
             let header_list = decoder.decode(&hex_dump).ok().unwrap();
 
-            assert_eq!(header_list, [
-                (b":status".to_vec(), b"302".to_vec()),
-                (b"cache-control".to_vec(), b"private".to_vec()),
-                (b"date".to_vec(), b"Mon, 21 Oct 2013 20:13:21 GMT".to_vec()),
-                (b"location".to_vec(), b"https://www.example.com".to_vec()),
-            ]);
+            assert_eq!(
+                header_list,
+                [
+                    (b":status".to_vec(), b"302".to_vec()),
+                    (b"cache-control".to_vec(), b"private".to_vec()),
+                    (b"date".to_vec(), b"Mon, 21 Oct 2013 20:13:21 GMT".to_vec()),
+                    (b"location".to_vec(), b"https://www.example.com".to_vec()),
+                ]
+            );
             // All entries in the dynamic table too?
             let expected_table = vec![
                 (b"location".to_vec(), b"https://www.example.com".to_vec()),
@@ -1051,12 +1096,15 @@ mod tests {
             let header_list = decoder.decode(&hex_dump).ok().unwrap();
 
             // Headers have been correctly decoded...
-            assert_eq!(header_list, [
-                (b":status".to_vec(), b"307".to_vec()),
-                (b"cache-control".to_vec(), b"private".to_vec()),
-                (b"date".to_vec(), b"Mon, 21 Oct 2013 20:13:21 GMT".to_vec()),
-                (b"location".to_vec(), b"https://www.example.com".to_vec()),
-            ]);
+            assert_eq!(
+                header_list,
+                [
+                    (b":status".to_vec(), b"307".to_vec()),
+                    (b"cache-control".to_vec(), b"private".to_vec()),
+                    (b"date".to_vec(), b"Mon, 21 Oct 2013 20:13:21 GMT".to_vec()),
+                    (b"location".to_vec(), b"https://www.example.com".to_vec()),
+                ]
+            );
             // Expect an empty table!
             let expected_table = vec![];
             let actual = decoder.header_table.dynamic_table.to_vec();
@@ -1074,42 +1122,45 @@ mod tests {
         {
             // First Request (B.4.1.)
             let hex_dump = [
-                0x82, 0x86, 0x84, 0x41, 0x8c, 0xf1, 0xe3, 0xc2, 0xe5, 0xf2,
-                0x3a, 0x6b, 0xa0, 0xab, 0x90, 0xf4, 0xff,
+                0x82, 0x86, 0x84, 0x41, 0x8c, 0xf1, 0xe3, 0xc2, 0xe5, 0xf2, 0x3a, 0x6b, 0xa0, 0xab,
+                0x90, 0xf4, 0xff,
             ];
 
             let header_list = decoder.decode(&hex_dump).ok().unwrap();
 
-            assert_eq!(header_list, [
-                (b":method".to_vec(), b"GET".to_vec()),
-                (b":scheme".to_vec(), b"http".to_vec()),
-                (b":path".to_vec(), b"/".to_vec()),
-                (b":authority".to_vec(), b"www.example.com".to_vec()),
-            ]);
+            assert_eq!(
+                header_list,
+                [
+                    (b":method".to_vec(), b"GET".to_vec()),
+                    (b":scheme".to_vec(), b"http".to_vec()),
+                    (b":path".to_vec(), b"/".to_vec()),
+                    (b":authority".to_vec(), b"www.example.com".to_vec()),
+                ]
+            );
             // Only one entry got added to the dynamic table?
             assert_eq!(decoder.header_table.dynamic_table.len(), 1);
-            let expected_table = vec![
-                (b":authority".to_vec(), b"www.example.com".to_vec())
-            ];
+            let expected_table = vec![(b":authority".to_vec(), b"www.example.com".to_vec())];
             let actual = decoder.header_table.dynamic_table.to_vec();
             assert_eq!(actual, expected_table);
         }
         {
             // Second Request (C.4.2.)
             let hex_dump = [
-                0x82, 0x86, 0x84, 0xbe, 0x58, 0x86, 0xa8, 0xeb, 0x10, 0x64,
-                0x9c, 0xbf,
+                0x82, 0x86, 0x84, 0xbe, 0x58, 0x86, 0xa8, 0xeb, 0x10, 0x64, 0x9c, 0xbf,
             ];
 
             let header_list = decoder.decode(&hex_dump).ok().unwrap();
 
-            assert_eq!(header_list, [
-                (b":method".to_vec(), b"GET".to_vec()),
-                (b":scheme".to_vec(), b"http".to_vec()),
-                (b":path".to_vec(), b"/".to_vec()),
-                (b":authority".to_vec(), b"www.example.com".to_vec()),
-                (b"cache-control".to_vec(), b"no-cache".to_vec()),
-            ]);
+            assert_eq!(
+                header_list,
+                [
+                    (b":method".to_vec(), b"GET".to_vec()),
+                    (b":scheme".to_vec(), b"http".to_vec()),
+                    (b":path".to_vec(), b"/".to_vec()),
+                    (b":authority".to_vec(), b"www.example.com".to_vec()),
+                    (b"cache-control".to_vec(), b"no-cache".to_vec()),
+                ]
+            );
             // One entry got added to the dynamic table, so we have two?
             let expected_table = vec![
                 (b"cache-control".to_vec(), b"no-cache".to_vec()),
@@ -1121,20 +1172,22 @@ mod tests {
         {
             // Third Request (C.4.3.)
             let hex_dump = [
-                0x82, 0x87, 0x85, 0xbf, 0x40, 0x88, 0x25, 0xa8, 0x49, 0xe9,
-                0x5b, 0xa9, 0x7d, 0x7f, 0x89, 0x25, 0xa8, 0x49, 0xe9, 0x5b,
-                0xb8, 0xe8, 0xb4, 0xbf,
+                0x82, 0x87, 0x85, 0xbf, 0x40, 0x88, 0x25, 0xa8, 0x49, 0xe9, 0x5b, 0xa9, 0x7d, 0x7f,
+                0x89, 0x25, 0xa8, 0x49, 0xe9, 0x5b, 0xb8, 0xe8, 0xb4, 0xbf,
             ];
 
             let header_list = decoder.decode(&hex_dump).ok().unwrap();
 
-            assert_eq!(header_list, [
-                (b":method".to_vec(), b"GET".to_vec()),
-                (b":scheme".to_vec(), b"https".to_vec()),
-                (b":path".to_vec(), b"/index.html".to_vec()),
-                (b":authority".to_vec(), b"www.example.com".to_vec()),
-                (b"custom-key".to_vec(), b"custom-value".to_vec()),
-            ]);
+            assert_eq!(
+                header_list,
+                [
+                    (b":method".to_vec(), b"GET".to_vec()),
+                    (b":scheme".to_vec(), b"https".to_vec()),
+                    (b":path".to_vec(), b"/index.html".to_vec()),
+                    (b":authority".to_vec(), b"www.example.com".to_vec()),
+                    (b"custom-key".to_vec(), b"custom-value".to_vec()),
+                ]
+            );
             // One entry got added to the dynamic table, so we have three at
             // this point...?
             let expected_table = vec![
@@ -1158,22 +1211,23 @@ mod tests {
         {
             // First Response (C.6.1.)
             let hex_dump = [
-                0x48, 0x82, 0x64, 0x02, 0x58, 0x85, 0xae, 0xc3, 0x77, 0x1a,
-                0x4b, 0x61, 0x96, 0xd0, 0x7a, 0xbe, 0x94, 0x10, 0x54, 0xd4,
-                0x44, 0xa8, 0x20, 0x05, 0x95, 0x04, 0x0b, 0x81, 0x66, 0xe0,
-                0x82, 0xa6, 0x2d, 0x1b, 0xff, 0x6e, 0x91, 0x9d, 0x29, 0xad,
-                0x17, 0x18, 0x63, 0xc7, 0x8f, 0x0b, 0x97, 0xc8, 0xe9, 0xae,
-                0x82, 0xae, 0x43, 0xd3,
+                0x48, 0x82, 0x64, 0x02, 0x58, 0x85, 0xae, 0xc3, 0x77, 0x1a, 0x4b, 0x61, 0x96, 0xd0,
+                0x7a, 0xbe, 0x94, 0x10, 0x54, 0xd4, 0x44, 0xa8, 0x20, 0x05, 0x95, 0x04, 0x0b, 0x81,
+                0x66, 0xe0, 0x82, 0xa6, 0x2d, 0x1b, 0xff, 0x6e, 0x91, 0x9d, 0x29, 0xad, 0x17, 0x18,
+                0x63, 0xc7, 0x8f, 0x0b, 0x97, 0xc8, 0xe9, 0xae, 0x82, 0xae, 0x43, 0xd3,
             ];
 
             let header_list = decoder.decode(&hex_dump).ok().unwrap();
 
-            assert_eq!(header_list, [
-                (b":status".to_vec(), b"302".to_vec()),
-                (b"cache-control".to_vec(), b"private".to_vec()),
-                (b"date".to_vec(), b"Mon, 21 Oct 2013 20:13:21 GMT".to_vec()),
-                (b"location".to_vec(), b"https://www.example.com".to_vec()),
-            ]);
+            assert_eq!(
+                header_list,
+                [
+                    (b":status".to_vec(), b"302".to_vec()),
+                    (b"cache-control".to_vec(), b"private".to_vec()),
+                    (b"date".to_vec(), b"Mon, 21 Oct 2013 20:13:21 GMT".to_vec()),
+                    (b"location".to_vec(), b"https://www.example.com".to_vec()),
+                ]
+            );
             // All entries in the dynamic table too?
             let expected_table = vec![
                 (b"location".to_vec(), b"https://www.example.com".to_vec()),
@@ -1186,18 +1240,19 @@ mod tests {
         }
         {
             // Second Response (C.6.2.)
-            let hex_dump = [
-                0x48, 0x83, 0x64, 0x0e, 0xff, 0xc1, 0xc0, 0xbf,
-            ];
+            let hex_dump = [0x48, 0x83, 0x64, 0x0e, 0xff, 0xc1, 0xc0, 0xbf];
 
             let header_list = decoder.decode(&hex_dump).ok().unwrap();
 
-            assert_eq!(header_list, [
-                (b":status".to_vec(), b"307".to_vec()),
-                (b"cache-control".to_vec(), b"private".to_vec()),
-                (b"date".to_vec(), b"Mon, 21 Oct 2013 20:13:21 GMT".to_vec()),
-                (b"location".to_vec(), b"https://www.example.com".to_vec()),
-            ]);
+            assert_eq!(
+                header_list,
+                [
+                    (b":status".to_vec(), b"307".to_vec()),
+                    (b"cache-control".to_vec(), b"private".to_vec()),
+                    (b"date".to_vec(), b"Mon, 21 Oct 2013 20:13:21 GMT".to_vec()),
+                    (b"location".to_vec(), b"https://www.example.com".to_vec()),
+                ]
+            );
             // The new status replaces the old status in the table, since it
             // cannot fit without evicting something from the table.
             let expected_table = vec![
@@ -1212,13 +1267,11 @@ mod tests {
         {
             // Third Response (C.6.3.)
             let hex_dump = [
-                0x88, 0xc1, 0x61, 0x96, 0xd0, 0x7a, 0xbe, 0x94, 0x10, 0x54,
-                0xd4, 0x44, 0xa8, 0x20, 0x05, 0x95, 0x04, 0x0b, 0x81, 0x66,
-                0xe0, 0x84, 0xa6, 0x2d, 0x1b, 0xff, 0xc0, 0x5a, 0x83, 0x9b,
-                0xd9, 0xab, 0x77, 0xad, 0x94, 0xe7, 0x82, 0x1d, 0xd7, 0xf2,
-                0xe6, 0xc7, 0xb3, 0x35, 0xdf, 0xdf, 0xcd, 0x5b, 0x39, 0x60,
-                0xd5, 0xaf, 0x27, 0x08, 0x7f, 0x36, 0x72, 0xc1, 0xab, 0x27,
-                0x0f, 0xb5, 0x29, 0x1f, 0x95, 0x87, 0x31, 0x60, 0x65, 0xc0,
+                0x88, 0xc1, 0x61, 0x96, 0xd0, 0x7a, 0xbe, 0x94, 0x10, 0x54, 0xd4, 0x44, 0xa8, 0x20,
+                0x05, 0x95, 0x04, 0x0b, 0x81, 0x66, 0xe0, 0x84, 0xa6, 0x2d, 0x1b, 0xff, 0xc0, 0x5a,
+                0x83, 0x9b, 0xd9, 0xab, 0x77, 0xad, 0x94, 0xe7, 0x82, 0x1d, 0xd7, 0xf2, 0xe6, 0xc7,
+                0xb3, 0x35, 0xdf, 0xdf, 0xcd, 0x5b, 0x39, 0x60, 0xd5, 0xaf, 0x27, 0x08, 0x7f, 0x36,
+                0x72, 0xc1, 0xab, 0x27, 0x0f, 0xb5, 0x29, 0x1f, 0x95, 0x87, 0x31, 0x60, 0x65, 0xc0,
                 0x03, 0xed, 0x4e, 0xe5, 0xb1, 0x06, 0x3d, 0x50, 0x07,
             ];
 
@@ -1232,7 +1285,7 @@ mod tests {
                 (b"content-encoding".to_vec(), b"gzip".to_vec()),
                 (
                     b"set-cookie".to_vec(),
-                    b"foo=ASDJKHQKBZXOQWEOPIUAXQWEOIU; max-age=3600; version=1".to_vec()
+                    b"foo=ASDJKHQKBZXOQWEOPIUAXQWEOIU; max-age=3600; version=1".to_vec(),
                 ),
             ];
             assert_eq!(header_list, expected_header_list);
@@ -1241,7 +1294,7 @@ mod tests {
             let expected_table = vec![
                 (
                     b"set-cookie".to_vec(),
-                    b"foo=ASDJKHQKBZXOQWEOPIUAXQWEOIU; max-age=3600; version=1".to_vec()
+                    b"foo=ASDJKHQKBZXOQWEOPIUAXQWEOIU; max-age=3600; version=1".to_vec(),
                 ),
                 (b"content-encoding".to_vec(), b"gzip".to_vec()),
                 (b"date".to_vec(), b"Mon, 21 Oct 2013 20:13:22 GMT".to_vec()),
@@ -1256,7 +1309,7 @@ mod tests {
     fn is_decoder_error(err: &DecoderError, result: &DecoderResult) -> bool {
         match *result {
             Err(ref e) => e == err,
-            _ => false
+            _ => false,
         }
     }
 
@@ -1285,9 +1338,12 @@ mod tests {
         // Check them all...
         for raw_message in raw_messages.iter() {
             assert!(
-                is_decoder_error(&DecoderError::HeaderIndexOutOfBounds,
-                                 &decoder.decode(&raw_message)),
-                "Expected index out of bounds");
+                is_decoder_error(
+                    &DecoderError::HeaderIndexOutOfBounds,
+                    &decoder.decode(&raw_message)
+                ),
+                "Expected index out of bounds"
+            );
         }
     }
 
@@ -1299,14 +1355,14 @@ mod tests {
         let mut decoder = Decoder::new();
         // Invalid padding introduced into the message
         let hex_dump = [
-            0x82, 0x86, 0x84, 0x41, 0x8c, 0xf1, 0xe3, 0xc2, 0xe5, 0xf2,
-            0x3a, 0x6b, 0xa0, 0xab, 0x90, 0xf4, 0xfe,
+            0x82, 0x86, 0x84, 0x41, 0x8c, 0xf1, 0xe3, 0xc2, 0xe5, 0xf2, 0x3a, 0x6b, 0xa0, 0xab,
+            0x90, 0xf4, 0xfe,
         ];
 
         assert!(match decoder.decode(&hex_dump) {
-            Err(DecoderError::StringDecodingError(
-                    StringDecodingError::HuffmanDecoderError(
-                        HuffmanDecoderError::InvalidPadding))) => true,
+            Err(DecoderError::StringDecodingError(StringDecodingError::HuffmanDecoderError(
+                HuffmanDecoderError::InvalidPadding,
+            ))) => true,
             _ => false,
         });
     }
@@ -1325,8 +1381,7 @@ mod tests {
         let result = decoder.decode(&hex_dump);
 
         assert!(match result {
-            Err(DecoderError::StringDecodingError(
-                    StringDecodingError::NotEnoughOctets)) => true,
+            Err(DecoderError::StringDecodingError(StringDecodingError::NotEnoughOctets)) => true,
             _ => false,
         });
     }
@@ -1339,15 +1394,13 @@ mod tests {
         // The message does not have the length specifier of the header value
         // (cuts short after the header key is complete)
         let hex_dump = [
-            0x40, 0x0a, b'c', b'u', b's', b't', b'o', b'm', b'-', b'k', b'e',
-            b'y',
+            0x40, 0x0a, b'c', b'u', b's', b't', b'o', b'm', b'-', b'k', b'e', b'y',
         ];
 
         let result = decoder.decode(&hex_dump);
 
         assert!(match result {
-            Err(DecoderError::IntegerDecodingError(
-                    IntegerDecodingError::NotEnoughOctets)) => true,
+            Err(DecoderError::IntegerDecodingError(IntegerDecodingError::NotEnoughOctets)) => true,
             _ => false,
         });
     }
@@ -1357,17 +1410,17 @@ mod tests {
 /// and some other encoder implementations, based on their results
 /// published at
 /// [http2jp/hpack-test-case](https://github.com/http2jp/hpack-test-case)
-#[cfg(feature="interop_tests")]
+#[cfg(feature = "interop_tests")]
 #[cfg(test)]
 mod interop_tests {
-    use std::io::Read;
-    use std::fs::{self, File};
-    use std::path::{Path, PathBuf};
     use std::collections::HashMap;
+    use std::fs::{self, File};
+    use std::io::Read;
+    use std::path::{Path, PathBuf};
 
-    use rustc_serialize::Decoder as JsonDecoder;
-    use rustc_serialize::{Decodable, json};
     use rustc_serialize::hex::FromHex;
+    use rustc_serialize::Decoder as JsonDecoder;
+    use rustc_serialize::{json, Decodable};
 
     use super::Decoder;
 
@@ -1399,39 +1452,38 @@ mod interop_tests {
     /// in the directory `fixtures/hpack/interop`.
     impl Decodable for TestFixture {
         fn decode<D: JsonDecoder>(d: &mut D) -> Result<Self, D::Error> {
-            d.read_struct("root", 0, |d| Ok(TestFixture {
-                wire_bytes: try!(d.read_struct_field("wire", 0, |d| {
-                    // Read the `wire` field...
-                    Decodable::decode(d).and_then(|res: String| {
-                        // If valid, parse out the octets from the String by
-                        // considering it a hex encoded byte sequence.
-                        Ok(res.from_hex().unwrap())
-                    })
-                })),
-                headers: try!(d.read_struct_field("headers", 0, |d| {
-                    // Read the `headers` field...
-                    d.read_seq(|d, len| {
-                        // ...since it's an array, we step into the sequence
-                        // and read each element.
-                        let mut ret: Vec<(Vec<u8>, Vec<u8>)> = Vec::new();
-                        for i in (0..len) {
-                            // Individual elements are encoded as a simple
-                            // JSON object with one key: value pair.
-                            let header: HashMap<String, String> = try!(
-                                d.read_seq_elt(i, |d| Decodable::decode(d)));
-                            // We convert it to a tuple, which is a more
-                            // natural representation of headers.
-                            for (name, value) in header.into_iter() {
-                                ret.push((
-                                    name.as_bytes().to_vec(),
-                                    value.as_bytes().to_vec()
-                                ));
+            d.read_struct("root", 0, |d| {
+                Ok(TestFixture {
+                    wire_bytes: d.read_struct_field("wire", 0, |d| {
+                        // Read the `wire` field...
+                        Decodable::decode(d).and_then(|res: String| {
+                            // If valid, parse out the octets from the String by
+                            // considering it a hex encoded byte sequence.
+                            Ok(res.from_hex().unwrap())
+                        })
+                    })?,
+                    headers: d.read_struct_field("headers", 0, |d| {
+                        // Read the `headers` field...
+                        d.read_seq(|d, len| {
+                            // ...since it's an array, we step into the sequence
+                            // and read each element.
+                            let mut ret: Vec<(Vec<u8>, Vec<u8>)> = Vec::new();
+                            for i in (0..len) {
+                                // Individual elements are encoded as a simple
+                                // JSON object with one key: value pair.
+                                let header: HashMap<String, String> =
+                                    d.read_seq_elt(i, |d| Decodable::decode(d))?;
+                                // We convert it to a tuple, which is a more
+                                // natural representation of headers.
+                                for (name, value) in header.into_iter() {
+                                    ret.push((name.as_bytes().to_vec(), value.as_bytes().to_vec()));
+                                }
                             }
-                        }
-                        Ok(ret)
-                    })
-                })),
-            }))
+                            Ok(ret)
+                        })
+                    })?,
+                })
+            })
         }
     }
 
@@ -1486,16 +1538,19 @@ mod interop_tests {
         let decoded: TestStory = json::decode(raw_json).unwrap();
 
         assert_eq!(decoded.cases.len(), 2);
-        assert_eq!(decoded.cases[0].wire_bytes, vec![
-            0x82, 0x86, 0x41, 0x88, 0xf4, 0x39, 0xce, 0x75, 0xc8, 0x75, 0xfa,
-            0x57, 0x84
-        ]);
-        assert_eq!(decoded.cases[0].headers, vec![
-            (b":method".to_vec(), b"GET".to_vec()),
-            (b":scheme".to_vec(), b"http".to_vec()),
-            (b":authority".to_vec(), b"yahoo.co.jp".to_vec()),
-            (b":path".to_vec(), b"/".to_vec()),
-        ]);
+        assert_eq!(
+            decoded.cases[0].wire_bytes,
+            vec![0x82, 0x86, 0x41, 0x88, 0xf4, 0x39, 0xce, 0x75, 0xc8, 0x75, 0xfa, 0x57, 0x84]
+        );
+        assert_eq!(
+            decoded.cases[0].headers,
+            vec![
+                (b":method".to_vec(), b"GET".to_vec()),
+                (b":scheme".to_vec(), b"http".to_vec()),
+                (b":authority".to_vec(), b"yahoo.co.jp".to_vec()),
+                (b":path".to_vec(), b"/".to_vec()),
+            ]
+        );
     }
 
     /// A helper function that performs an interop test for a given story file.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,22 +2,23 @@
 //! performing the encoding and decoding of header sets, according to the
 //! HPACK spec.
 
-#[macro_use] extern crate log;
-#[cfg(feature="interop_tests")]
+#[macro_use]
+extern crate log;
+#[cfg(feature = "interop_tests")]
 extern crate rustc_serialize;
 
+use std::collections::vec_deque;
+use std::collections::VecDeque;
 use std::fmt;
 use std::iter;
 use std::slice;
-use std::collections::VecDeque;
-use std::collections::vec_deque;
 
 // Re-export the main HPACK API entry points.
 pub use self::decoder::Decoder;
 pub use self::encoder::Encoder;
 
-pub mod encoder;
 pub mod decoder;
+pub mod encoder;
 pub mod huffman;
 
 /// An `Iterator` through elements of the `DynamicTable`.
@@ -219,10 +220,12 @@ struct HeaderTableIter<'a> {
     // The mapper is required to transform the elements yielded from the static
     // table to a type that matches the elements yielded from the dynamic table.
     inner: iter::Chain<
-            iter::Map<
-                slice::Iter<'a, (&'a [u8], &'a [u8])>,
-                fn((&'a (&'a [u8], &'a [u8]))) -> (&'a [u8], &'a [u8])>,
-            DynamicTableIter<'a>>,
+        iter::Map<
+            slice::Iter<'a, (&'a [u8], &'a [u8])>,
+            fn(&'a (&'a [u8], &'a [u8])) -> (&'a [u8], &'a [u8]),
+        >,
+        DynamicTableIter<'a>,
+    >,
 }
 
 impl<'a> Iterator for HeaderTableIter<'a> {
@@ -242,8 +245,7 @@ impl<'a> Iterator for HeaderTableIter<'a> {
 /// `HeaderTableIter` we need to be able to refer to a real type for the Fn
 /// template parameter, which means that when instantiating an instance, a
 /// closure cannot be passed, since it cannot be named.
-fn static_table_mapper<'a>(h: &'a (&'a [u8], &'a [u8]))
-        -> (&'a [u8], &'a [u8]) {
+fn static_table_mapper<'a>(h: &'a (&'a [u8], &'a [u8])) -> (&'a [u8], &'a [u8]) {
     *h
 }
 
@@ -275,10 +277,11 @@ impl<'a> HeaderTable<'a> {
     /// corresponds to the header name, value pairs in the described order.
     pub fn iter(&'a self) -> HeaderTableIter<'a> {
         HeaderTableIter {
-            inner: self.static_table.iter()
-                                    .map(static_table_mapper as
-                                            fn((&'a (&'a [u8], &'a [u8]))) -> (&'a [u8], &'a [u8]))
-                                    .chain(self.dynamic_table.iter()),
+            inner: self
+                .static_table
+                .iter()
+                .map(static_table_mapper as fn(&'a (&'a [u8], &'a [u8])) -> (&'a [u8], &'a [u8]))
+                .chain(self.dynamic_table.iter()),
         }
     }
 
@@ -302,16 +305,11 @@ impl<'a> HeaderTable<'a> {
     ///
     /// This is according to the [HPACK spec, section 2.3.3.]
     /// (http://http2.github.io/http2-spec/compression.html#index.address.space)
-    pub fn get_from_table(&self, index: usize)
-            -> Option<(&[u8], &[u8])> {
+    pub fn get_from_table(&self, index: usize) -> Option<(&[u8], &[u8])> {
         // The IETF defined table indexing as 1-based.
         // So, before starting, make sure the given index is within the proper
         // bounds.
-        let real_index = if index > 0 {
-            index - 1
-        } else {
-            return None
-        };
+        let real_index = if index > 0 { index - 1 } else { return None };
 
         if real_index < self.static_table.len() {
             // It is in the static table so just return that...
@@ -321,10 +319,8 @@ impl<'a> HeaderTable<'a> {
             let dynamic_index = real_index - self.static_table.len();
             if dynamic_index < self.dynamic_table.len() {
                 match self.dynamic_table.get(dynamic_index) {
-                    Some(&(ref name, ref value)) => {
-                        Some((name, value))
-                    },
-                    None => None
+                    Some(&(ref name, ref value)) => Some((name, value)),
+                    None => None,
                 }
             } else {
                 // Index out of bounds!
@@ -379,67 +375,67 @@ impl<'a> HeaderTable<'a> {
 /// The table represents the static header table defined by the HPACK spec.
 /// (HPACK, Appendix A)
 static STATIC_TABLE: &'static [(&'static [u8], &'static [u8])] = &[
-  (b":authority", b""),
-  (b":method", b"GET"),
-  (b":method", b"POST"),
-  (b":path", b"/"),
-  (b":path", b"/index.html"),
-  (b":scheme", b"http"),
-  (b":scheme", b"https"),
-  (b":status", b"200"),
-  (b":status", b"204"),
-  (b":status", b"206"),
-  (b":status", b"304"),
-  (b":status", b"400"),
-  (b":status", b"404"),
-  (b":status", b"500"),
-  (b"accept-", b""),
-  (b"accept-encoding", b"gzip, deflate"),
-  (b"accept-language", b""),
-  (b"accept-ranges", b""),
-  (b"accept", b""),
-  (b"access-control-allow-origin", b""),
-  (b"age", b""),
-  (b"allow", b""),
-  (b"authorization", b""),
-  (b"cache-control", b""),
-  (b"content-disposition", b""),
-  (b"content-encoding", b""),
-  (b"content-language", b""),
-  (b"content-length", b""),
-  (b"content-location", b""),
-  (b"content-range", b""),
-  (b"content-type", b""),
-  (b"cookie", b""),
-  (b"date", b""),
-  (b"etag", b""),
-  (b"expect", b""),
-  (b"expires", b""),
-  (b"from", b""),
-  (b"host", b""),
-  (b"if-match", b""),
-  (b"if-modified-since", b""),
-  (b"if-none-match", b""),
-  (b"if-range", b""),
-  (b"if-unmodified-since", b""),
-  (b"last-modified", b""),
-  (b"link", b""),
-  (b"location", b""),
-  (b"max-forwards", b""),
-  (b"proxy-authenticate", b""),
-  (b"proxy-authorization", b""),
-  (b"range", b""),
-  (b"referer", b""),
-  (b"refresh", b""),
-  (b"retry-after", b""),
-  (b"server", b""),
-  (b"set-cookie", b""),
-  (b"strict-transport-security", b""),
-  (b"transfer-encoding", b""),
-  (b"user-agent", b""),
-  (b"vary", b""),
-  (b"via", b""),
-  (b"www-authenticate", b""),
+    (b":authority", b""),
+    (b":method", b"GET"),
+    (b":method", b"POST"),
+    (b":path", b"/"),
+    (b":path", b"/index.html"),
+    (b":scheme", b"http"),
+    (b":scheme", b"https"),
+    (b":status", b"200"),
+    (b":status", b"204"),
+    (b":status", b"206"),
+    (b":status", b"304"),
+    (b":status", b"400"),
+    (b":status", b"404"),
+    (b":status", b"500"),
+    (b"accept-", b""),
+    (b"accept-encoding", b"gzip, deflate"),
+    (b"accept-language", b""),
+    (b"accept-ranges", b""),
+    (b"accept", b""),
+    (b"access-control-allow-origin", b""),
+    (b"age", b""),
+    (b"allow", b""),
+    (b"authorization", b""),
+    (b"cache-control", b""),
+    (b"content-disposition", b""),
+    (b"content-encoding", b""),
+    (b"content-language", b""),
+    (b"content-length", b""),
+    (b"content-location", b""),
+    (b"content-range", b""),
+    (b"content-type", b""),
+    (b"cookie", b""),
+    (b"date", b""),
+    (b"etag", b""),
+    (b"expect", b""),
+    (b"expires", b""),
+    (b"from", b""),
+    (b"host", b""),
+    (b"if-match", b""),
+    (b"if-modified-since", b""),
+    (b"if-none-match", b""),
+    (b"if-range", b""),
+    (b"if-unmodified-since", b""),
+    (b"last-modified", b""),
+    (b"link", b""),
+    (b"location", b""),
+    (b"max-forwards", b""),
+    (b"proxy-authenticate", b""),
+    (b"proxy-authorization", b""),
+    (b"range", b""),
+    (b"referer", b""),
+    (b"refresh", b""),
+    (b"retry-after", b""),
+    (b"server", b""),
+    (b"set-cookie", b""),
+    (b"strict-transport-security", b""),
+    (b"transfer-encoding", b""),
+    (b"user-agent", b""),
+    (b"vary", b""),
+    (b"via", b""),
+    (b"www-authenticate", b""),
 ];
 
 #[cfg(test)]
@@ -483,8 +479,7 @@ mod tests {
         // Resized?
         assert_eq!(32 + 6, table.get_size());
         // Only has the second header?
-        assert_eq!(table.to_vec(), vec![
-            (b"123".to_vec(), b"456".to_vec())]);
+        assert_eq!(table.to_vec(), vec![(b"123".to_vec(), b"456".to_vec())]);
     }
 
     /// Tests that when inserting a new header whose size is larger than the
@@ -516,8 +511,7 @@ mod tests {
         table.set_max_table_size(38);
 
         assert_eq!(32 + 2, table.get_size());
-        assert_eq!(table.to_vec(), vec![
-            (b"c".to_vec(), b"d".to_vec())]);
+        assert_eq!(table.to_vec(), vec![(b"c".to_vec(), b"d".to_vec())]);
     }
 
     /// Tests that setting the maximum table size to 0 clears the dynamic
@@ -563,11 +557,7 @@ mod tests {
 
         let iter_res: Vec<(&[u8], &[u8])> = table.iter().collect();
 
-        let expected: Vec<(&[u8], &[u8])> = vec![
-            (b"c", b"d"),
-            (b"123", b"456"),
-            (b"a", b"b"),
-        ];
+        let expected: Vec<(&[u8], &[u8])> = vec![(b"c", b"d"), (b"123", b"456"), (b"a", b"b")];
         assert_eq!(iter_res, expected);
     }
 
@@ -625,8 +615,10 @@ mod tests {
 
         table.add_header(header.0.clone(), header.1.clone());
 
-        assert_eq!(table.get_from_table(STATIC_TABLE.len() + 1).unwrap(),
-                   ((&header.0[..], &header.1[..])));
+        assert_eq!(
+            table.get_from_table(STATIC_TABLE.len() + 1).unwrap(),
+            ((&header.0[..], &header.1[..]))
+        );
     }
 
     /// Tests that the `iter` method of the `HeaderTable` returns an iterator
@@ -635,10 +627,7 @@ mod tests {
     #[test]
     fn test_header_table_iter() {
         let mut table = HeaderTable::with_static_table(STATIC_TABLE);
-        let headers: [(&[u8], &[u8]); 2] = [
-            (b"a", b"b"),
-            (b"c", b"d"),
-        ];
+        let headers: [(&[u8], &[u8]); 2] = [(b"a", b"b"), (b"c", b"d")];
         for header in headers.iter() {
             table.add_header(header.0.to_vec(), header.1.to_vec());
         }
@@ -652,8 +641,11 @@ mod tests {
         }
         // Part of the dynamic table correctly iterated through: the elements
         // are in reversed order of insertion in the dynamic table.
-        for (h1, h2) in iterated.iter().skip(STATIC_TABLE.len())
-                                .zip(headers.iter().rev()) {
+        for (h1, h2) in iterated
+            .iter()
+            .skip(STATIC_TABLE.len())
+            .zip(headers.iter().rev())
+        {
             assert_eq!(h1, h2);
         }
     }
@@ -665,8 +657,7 @@ mod tests {
         let table = HeaderTable::with_static_table(STATIC_TABLE);
 
         for (i, h) in STATIC_TABLE.iter().enumerate() {
-            assert_eq!(table.find_header(*h).unwrap(),
-                       (i + 1, true));
+            assert_eq!(table.find_header(*h).unwrap(), (i + 1, true));
         }
     }
 
@@ -719,7 +710,6 @@ mod tests {
             }
         }
     }
-
 
     /// Tests that searching for an entry in the header table, which should be
     /// fully in the dynamic table (both name and value), works correctly.


### PR DESCRIPTION
### This PR is for:

- Libs

### Limit dynamic table storage elements to reduce dynamic table size
#### Checklist
- [ ] Added unit test.
#### Backport to branches
- main
#### Changes
- Added the  new_with_header_filter function for the Decoder. The header filter is used to filter headers that are not within the business scope, and the name and value of these headers are not written to the dynamic table, but in order for the dynamic table to be indexed correctly, a place is reserved for these headers in the dynamic table and replaced by "None"