### PR TITLE
Replace huffman decoder with httlib-huffman

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,7 @@ documentation = "https://mlalic.github.io/hpack-rs/hpack/index.html"
 interop_tests = ["rustc-serialize"]
 
 [dependencies]
+httlib-huffman = "0.3"
 log = "^0.3"
 
 [dependencies.rustc-serialize]

--- a/src/huffman.rs
+++ b/src/huffman.rs
@@ -26,10 +26,7 @@ impl HuffmanCodeSymbol {
 }
 
 /// Represents the error variants that the `HuffmanDecoder` can return.
-#[derive(PartialEq)]
-#[derive(Copy)]
-#[derive(Clone)]
-#[derive(Debug)]
+#[derive(PartialEq, Copy, Clone, Debug)]
 pub enum HuffmanDecoderError {
     /// Any padding strictly larger than 7 bits MUST be interpreted as an error
     PaddingTooLarge,
@@ -38,6 +35,8 @@ pub enum HuffmanDecoderError {
     InvalidPadding,
     /// If EOS is ever found in the string, it causes an error.
     EOSInString,
+    /// A generic error
+    InvalidInput,
 }
 
 /// The type that represents the result of the `decode` method of the
@@ -60,8 +59,7 @@ impl HuffmanDecoder {
             panic!("Invalid Huffman code table. It must define exactly 257 symbols.");
         }
 
-        let mut decoder_table: HashMap<u8, HashMap<u32, HuffmanCodeSymbol>> =
-            HashMap::new();
+        let mut decoder_table: HashMap<u8, HashMap<u32, HuffmanCodeSymbol>> = HashMap::new();
         let mut eos_codepoint: Option<(u32, u8)> = None;
 
         for (symbol, &(code, code_len)) in table.iter().enumerate() {
@@ -75,7 +73,7 @@ impl HuffmanDecoder {
                     // We also remember the code point of the EOS for easier
                     // reference later on.
                     eos_codepoint = Some((code, code_len));
-                },
+                }
                 _ => {}
             };
             subtable.insert(code, huff_symbol);
@@ -119,7 +117,7 @@ impl HuffmanDecoder {
                             // If the EOS symbol is detected within the stream,
                             // we need to consider it an error.
                             return Err(HuffmanDecoderError::EOSInString);
-                        },
+                        }
                     };
                     result.push(decoded_symbol);
                     current = 0;
@@ -135,7 +133,7 @@ impl HuffmanDecoder {
 
         // First: the check for the length of the padding
         if current_len > 7 {
-            return Err(HuffmanDecoderError::PaddingTooLarge)
+            return Err(HuffmanDecoderError::PaddingTooLarge);
         }
 
         // Second: the padding corresponds to the most-significant bits of the
@@ -182,7 +180,9 @@ struct BitIterator<'a, I: Iterator> {
 }
 
 impl<'a, I: Iterator> BitIterator<'a, I>
-        where I: Iterator<Item=&'a u8> {
+where
+    I: Iterator<Item = &'a u8>,
+{
     pub fn new(iterator: I) -> BitIterator<'a, I> {
         BitIterator::<'a, I> {
             buffer_iterator: iterator,
@@ -193,7 +193,9 @@ impl<'a, I: Iterator> BitIterator<'a, I>
 }
 
 impl<'a, I> Iterator for BitIterator<'a, I>
-        where I: Iterator<Item=&'a u8> {
+where
+    I: Iterator<Item = &'a u8>,
+{
     type Item = bool;
 
     fn next(&mut self) -> Option<bool> {
@@ -492,15 +494,12 @@ mod tests {
     /// A helper function that converts the given slice containing values `1`
     /// and `0` to a `Vec` of `bool`s, according to the number.
     fn to_expected_bit_result(numbers: &[u8]) -> Vec<bool> {
-        numbers.iter().map(|b| -> bool {
-            *b == 1
-        }).collect()
+        numbers.iter().map(|b| -> bool { *b == 1 }).collect()
     }
 
     #[test]
     fn test_bit_iterator_single_byte() {
-        let expected_result = to_expected_bit_result(
-            &[0, 0, 0, 0, 1, 0, 1, 0]);
+        let expected_result = to_expected_bit_result(&[0, 0, 0, 0, 1, 0, 1, 0]);
 
         let mut res: Vec<bool> = Vec::new();
         for b in BitIterator::new(vec![10u8].iter()) {
@@ -512,13 +511,10 @@ mod tests {
 
     #[test]
     fn test_bit_iterator_multiple_bytes() {
-        let expected_result = to_expected_bit_result(
-            &[0, 0, 0, 0, 1, 0, 1, 0,
-              1, 1, 1, 1, 1, 1, 1, 1,
-              1, 0, 0, 0, 0, 0, 0, 0,
-              0, 0, 0, 0, 0, 0, 0, 1,
-              0, 0, 0, 0, 0, 0, 0, 0,
-              1, 0, 1, 0, 1, 0, 1, 0]);
+        let expected_result = to_expected_bit_result(&[
+            0, 0, 0, 0, 1, 0, 1, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+            0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 1, 0, 1, 0, 1, 0,
+        ]);
 
         let mut res: Vec<bool> = Vec::new();
         for b in BitIterator::new(vec![10u8, 255, 128, 1, 0, 170].iter()) {
@@ -629,10 +625,13 @@ mod tests {
 
             let result = decoder.decode(&hex_buffer);
 
-            assert_eq!(HuffmanDecoderError::EOSInString, match result {
-                Err(e) => e,
-                _ => panic!("Expected error due to EOS symbol in string"),
-            });
+            assert_eq!(
+                HuffmanDecoderError::EOSInString,
+                match result {
+                    Err(e) => e,
+                    _ => panic!("Expected error due to EOS symbol in string"),
+                }
+            );
         }
         {
             // Full EOS after a valid character.
@@ -640,10 +639,13 @@ mod tests {
 
             let result = decoder.decode(&hex_buffer);
 
-            assert_eq!(HuffmanDecoderError::EOSInString, match result {
-                Err(e) => e,
-                _ => panic!("Expected error due to EOS symbol in string"),
-            });
+            assert_eq!(
+                HuffmanDecoderError::EOSInString,
+                match result {
+                    Err(e) => e,
+                    _ => panic!("Expected error due to EOS symbol in string"),
+                }
+            );
         }
     }
 
@@ -667,10 +669,13 @@ mod tests {
 
         let result = decoder.decode(&hex_buffer);
 
-        assert_eq!(HuffmanDecoderError::PaddingTooLarge, match result {
-            Err(e) => e,
-            _ => panic!("Expected `PaddingTooLarge` error"),
-        });
+        assert_eq!(
+            HuffmanDecoderError::PaddingTooLarge,
+            match result {
+                Err(e) => e,
+                _ => panic!("Expected `PaddingTooLarge` error"),
+            }
+        );
     }
 
     /// Tests that when there is a certain number of padding bits that deviate
@@ -683,20 +688,26 @@ mod tests {
 
             let result = decoder.decode(&hex_buffer);
 
-            assert_eq!(HuffmanDecoderError::InvalidPadding, match result {
-                Err(e) => e,
-                _ => panic!("Expected `InvalidPadding` error"),
-            });
+            assert_eq!(
+                HuffmanDecoderError::InvalidPadding,
+                match result {
+                    Err(e) => e,
+                    _ => panic!("Expected `InvalidPadding` error"),
+                }
+            );
         }
         {
             let hex_buffer = [254, 0];
 
             let result = decoder.decode(&hex_buffer);
 
-            assert_eq!(HuffmanDecoderError::InvalidPadding, match result {
-                Err(e) => e,
-                _ => panic!("Expected `InvalidPadding` error"),
-            });
+            assert_eq!(
+                HuffmanDecoderError::InvalidPadding,
+                match result {
+                    Err(e) => e,
+                    _ => panic!("Expected `InvalidPadding` error"),
+                }
+            );
         }
     }
 }


### PR DESCRIPTION
这个库进行哈夫曼解码时构造了编码长度和编码的二维 hashmap 进行查询，查询方法是从短到长逐个在 map 中寻找对应的字符

性能很糟糕的地方在于每次解码时都重新构造了这个 map，而这个 map 对于 hpack 来说是固定不变的

第一个版本（staticmap）将 map 构造优化为一次，但实际上有更好的解码算法，大致思想是用转移表来减少查找次数

下表中的 5b/4b/3b/2b/1b 表示每次查表的位数，理论上越大越快，同时查找表的内存也增大（不过是静态的，对于 http2 来说就是一个表）

数据是用 [haskell-http2-static-huffman](https://github.com/http2jp/hpack-test-case/tree/master/haskell-http2-static-huffman) 测得

| 类型 | cpu time | memory |
| - | - | - |
| origin | 1.5s | 2,795,373 allocs, 2,795,369 frees, 511,414,692 bytes allocated |
| staticmap | 200ms | 143,323 allocs, 143,297 frees, 13,171,492 bytes allocated |
| 5b | 17.2ms | 92,291 allocs, 92,287 frees, 13,812,816 bytes allocated |
| 4b | 19.4ms | 同上 |
| 3b | 20.9ms | 同上 |
| 2b | 26.6ms | 同上 |
| 1b | 40.6ms | 同上 |

本改动直接将解码换成了 5bit 版本